### PR TITLE
fix(list): add products one by one on 'produtos' array and adjust ini…

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/br/unicamp/ic/inf335/Brecho.java" charset="ISO-8859-1" />
+  </component>
+</project>

--- a/src/br/unicamp/ic/inf335/Brecho.java
+++ b/src/br/unicamp/ic/inf335/Brecho.java
@@ -11,15 +11,20 @@ public class Brecho {
 	
 	public static void main(String[] args) {
 		ProdutoBean nProg = new ProdutoBean("CD00001","Celular Galaxy S10", "128 Gb, Preto, com Carregador",1250.0,"Poucos riscos, estado de novo.");
+        produtos.add(nProg);
 		nProg = new ProdutoBean("CD00002","Prod 2 ...", "Bla Bla Bla",1100.0,"Bla Bla Bla");
+        produtos.add(nProg);
 		nProg = new ProdutoBean("CD00003","Prod 3 ...", "Bla Bla Bla",120.0,"Bla Bla Bla");
+        produtos.add(nProg);
 		nProg = new ProdutoBean("CD00004","Prod 4 ...", "Bla Bla Bla",1300.0,"Bla Bla Bla");
+        produtos.add(nProg);
 		nProg = new ProdutoBean("CD00005","Prod 5 ...", "Bla Bla Bla",9400.0,"Bla Bla Bla");
+        produtos.add(nProg);
 		nProg = new ProdutoBean("CD00006","Prod 6 ...", "Bla Bla Bla",1500.0,"Bla Bla Bla");
-		produtos.add(nProg);
+        produtos.add(nProg);
 		
 		// Imprime produtos
-		for (int i=1; i<=produtos.size(); i++) {
+		for (int i=0; i < produtos.size(); i++) {
 			System.out.println("Codigo = " + produtos.get(i).getCodigo() + " Nome = " + produtos.get(i).getNome() + " Valor = " + produtos.get(i).getValor());
 		}
 		
@@ -28,7 +33,7 @@ public class Brecho {
 		
 		System.out.println("-------------------- Produtos Ordenados -------------------");
 		// Imprime produtos ordenados
-		for (int i=1; i<=produtos.size(); i++) {
+		for (int i=0; i < produtos.size(); i++) {
 			System.out.println("Codigo = " + produtos.get(i).getCodigo() + " Nome = " + produtos.get(i).getNome() + " Valor = " + produtos.get(i).getValor());
 		}
 		


### PR DESCRIPTION
This pull request includes improvements to the product list initialization and iteration logic in `Brecho.java`, as well as the addition of an IDE configuration file. The main focus is on ensuring all products are added to the list and correcting the iteration bounds when printing products.

Product list initialization and iteration fixes:

* Ensured that every `ProdutoBean` instance created is added to the `produtos` list, which was previously missing for several products.
* Corrected the for-loop bounds when printing products, changing the start index from 1 to 0 and the loop condition to use `< produtos.size()` instead of `<= produtos.size()`. This prevents skipping the first product and avoids an out-of-bounds error. [[1]](diffhunk://#diff-a5de95f3289a672bee40fe8974caa9c7456a0b269caca225dfc31705b415633aR14-R27) [[2]](diffhunk://#diff-a5de95f3289a672bee40fe8974caa9c7456a0b269caca225dfc31705b415633aL31-R36)

IDE configuration:

* Added `.idea/encodings.xml` to specify the file encoding for `Brecho.java`, ensuring consistent character encoding in development environments.