### PR TITLE
fix(average): fix products average price calc

### DIFF
--- a/src/br/unicamp/ic/inf335/Brecho.java
+++ b/src/br/unicamp/ic/inf335/Brecho.java
@@ -37,14 +37,14 @@ public class Brecho {
 			System.out.println("Codigo = " + produtos.get(i).getCodigo() + " Nome = " + produtos.get(i).getNome() + " Valor = " + produtos.get(i).getValor());
 		}
 		
-		// Calcula Média
+		// Calcula Media
 		Double media = 0.0;
-		int i = 1;
-		while (i<=produtos.size()) {
-			media = produtos.get(i).getValor();
+		int i = 0;
+		while (i < produtos.size()) {
+			media += produtos.get(i).getValor();
 			i++;
 		}
-		media = media / i;
+		media = media / produtos.size();
 		System.out.println("Media de Valores = " + media);
 	}
 


### PR DESCRIPTION
This pull request fixes the calculation of the average value of products in the `main` method of `Brecho.java`. The update corrects the loop indexing and the accumulation of product values to ensure the average is computed accurately.

Bug fix in average calculation:

* Changed the loop to start indexing at 0 instead of 1, and correctly accumulate the sum of product values in the `media` variable. The average is now divided by the correct number of products (`produtos.size()`), fixing the previous logic error.