### PR TITLE
fix(product): fix product compareTo method, to fix ordered list

### DIFF
--- a/src/br/unicamp/ic/inf335/beans/ProdutoBean.java
+++ b/src/br/unicamp/ic/inf335/beans/ProdutoBean.java
@@ -68,10 +68,10 @@ public class ProdutoBean implements java.io.Serializable, Comparable<ProdutoBean
 	public int compareTo(ProdutoBean p) {
 		if (valor > p.getValor()) {
 			return 1;
-		} else if (valor > p.getValor()) {
+		} else if (valor < p.getValor()) {
 			return -1;
-		} else
-		    return 0;
+		}
+        return 0;
 	}
 	
 	


### PR DESCRIPTION
This pull request fixes a logic error in the `compareTo` method of the `ProdutoBean` class. The method now correctly compares the `valor` fields, ensuring proper ordering when sorting or comparing `ProdutoBean` instances.

- Fixed the conditional in the `compareTo` method of `ProdutoBean` so that it now correctly returns `-1` when the current object's `valor` is less than the compared object's `valor`.